### PR TITLE
Various security / model improvements

### DIFF
--- a/crates/laguna-backend-api/src/login.rs
+++ b/crates/laguna-backend-api/src/login.rs
@@ -21,7 +21,6 @@ use crate::state::UserState;
 ///      --data '{
 ///                 "username_or_email": "test",
 ///                 "password": "test123",
-///                 "login_timestamp": "2023-07-04T10:18:17.391698Z"
 ///              }'
 /// ```
 /// ### Response (OK)
@@ -68,7 +67,7 @@ pub async fn login(
     if let Some(logged_user) = fetched_user {
         if logged_user.password == format!("{:x}", Sha256::digest(&login_dto.password)) {
             sqlx::query("UPDATE \"User\" SET last_login = $1 WHERE id = $2")
-                .bind(login_dto.login_timestamp)
+                .bind(chrono::offset::Utc::now())
                 .bind(logged_user.id)
                 .execute(pool.get_ref())
                 .await?;

--- a/crates/laguna-backend-api/src/login.rs
+++ b/crates/laguna-backend-api/src/login.rs
@@ -34,9 +34,9 @@ use crate::state::UserState;
 /// {
 ///     "LoginSuccess": {
 ///         "user": {
+///             "id": "b33b630d-e098-47d0-bc21-94c6a7467f17"
 ///             "username": "test",
 ///             "email": "test@laguna.io",
-///             "password": "ecd71870d1963316a97e3ac3408c9835ad8cf0f3c1bc703527c30265534f75ae",
 ///             "first_login": "2023-07-04T10:18:17.391698Z",
 ///             "last_login": "2023-07-04T10:18:17.391698Z",
 ///             "avatar_url": null,

--- a/crates/laguna-backend-api/src/register.rs
+++ b/crates/laguna-backend-api/src/register.rs
@@ -2,7 +2,7 @@ use actix_web::post;
 use actix_web::{web, HttpResponse};
 use digest::Digest;
 
-use laguna_backend_model::user::{User, UserDTO};
+use laguna_backend_model::{register::RegisterDTO, user::User};
 use sha2::Sha256;
 use sqlx::PgPool;
 
@@ -19,14 +19,6 @@ use crate::state::UserState;
 ///    "username": "test",
 ///    "email": "test@laguna.io",
 ///    "password": "test123",
-///    "first_login": null,
-///    "last_login": null,
-///    "avatar_url": null,
-///    "role": "Admin",
-///    "is_active": null,
-///    "has_verified_email": null,
-///    "is_history_private": null,
-///    "is_profile_private": null
 ///  }'
 /// ```
 /// ### Response (on successful register)
@@ -34,28 +26,12 @@ use crate::state::UserState;
 /// RegistrationSuccess
 /// ```
 /// ### Response (on already registered)
-/// ```json
-/// {
-///     "AlreadyRegistered": {
-///         "user": {
-///             "username": "test",
-///             "email": "test@laguna.io",
-///             "password": "ecd71870d1963316a97e3ac3408c9835ad8cf0f3c1bc703527c30265534f75ae",
-///             "first_login": "2023-07-04T10:18:17.391698Z",
-///             "last_login": "2023-07-04T10:18:17.391698Z",
-///             "avatar_url": null,
-///             "role": "Admin",
-///             "is_active": true,
-///             "has_verified_email": false,
-///             "is_history_private": true,
-///             "is_profile_private": true
-///         }
-///     }
-/// }
+/// ```text
+/// AlreadyRegistered
 /// ```
 #[post("/register")]
 pub async fn register(
-    user_dto: web::Json<UserDTO>,
+    user_dto: web::Json<RegisterDTO>,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, APIError> {
     let fetched_user =
@@ -65,24 +41,19 @@ pub async fn register(
             .fetch_optional(pool.get_ref())
             .await?;
 
-    if let Some(registered_user) = fetched_user {
-        return Ok(
-            HttpResponse::AlreadyReported().json(UserState::AlreadyRegistered {
-                user: registered_user.into(),
-            }),
-        );
+    if let Some(_) = fetched_user {
+        return Ok(HttpResponse::AlreadyReported().json(UserState::AlreadyRegistered));
     }
     // TODO: Verify email
     sqlx::query(
         r#"
-        INSERT INTO "User" (username, email, password, role)
-        VALUES ($1, $2, $3, $4);
+        INSERT INTO "User" (username, email, password)
+        VALUES ($1, $2, $3);
     "#,
     )
     .bind(&user_dto.username)
     .bind(&user_dto.email)
     .bind(format!("{:x}", Sha256::digest(&user_dto.password)))
-    .bind(&user_dto.role)
     .execute(pool.get_ref())
     .await?;
     Ok(HttpResponse::Ok().json(UserState::RegistrationSuccess))

--- a/crates/laguna-backend-api/src/state.rs
+++ b/crates/laguna-backend-api/src/state.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum UserState {
-    AlreadyRegistered { user: UserDTO },
+    AlreadyRegistered,
     RegistrationSuccess,
     LoginSuccess { user: UserDTO },
 }

--- a/crates/laguna-backend-api/tests/auth.rs
+++ b/crates/laguna-backend-api/tests/auth.rs
@@ -19,7 +19,8 @@ use jwt_compact::{
 use laguna_backend_api::{login::login, register::register, user::me};
 use laguna_backend_model::{
     login::LoginDTO,
-    user::{Role, UserDTO, Behaviour},
+    register::RegisterDTO,
+    user::{Behaviour, Role, UserDTO},
 };
 
 use sqlx::{postgres::PgPoolOptions, PgPool};
@@ -65,19 +66,10 @@ async fn test_register() {
     )
     .await;
     let req = TestRequest::post()
-        .set_json(UserDTO {
+        .set_json(RegisterDTO {
             username: String::from("test"),
             email: String::from("test@laguna.io"),
             password: String::from("test123"),
-            avatar_url: None,
-            role: Role::Admin,
-            behaviour: Behaviour::Lurker,
-            is_active: None,
-            is_history_private: None,
-            first_login: None,
-            last_login: None,
-            has_verified_email: None,
-            is_profile_private: None,
         })
         .uri("/register");
     let res: ServiceResponse = app.call(req.to_request()).await.unwrap();
@@ -85,19 +77,10 @@ async fn test_register() {
 
     // Test already exists
     let req = TestRequest::post()
-        .set_json(UserDTO {
+        .set_json(RegisterDTO {
             username: String::from("test"),
             email: String::from("test@laguna.io"),
             password: String::from("test123"),
-            avatar_url: None,
-            role: Role::Admin,
-            behaviour: Behaviour::Lurker,
-            is_active: None,
-            is_history_private: None,
-            first_login: None,
-            last_login: None,
-            has_verified_email: None,
-            is_profile_private: None,
         })
         .uri("/register");
 
@@ -133,19 +116,10 @@ async fn test_login() {
     .await;
 
     let req = TestRequest::post()
-        .set_json(UserDTO {
+        .set_json(RegisterDTO {
             username: String::from("test_login"),
             email: String::from("test_login@laguna.io"),
             password: String::from("test123"),
-            avatar_url: None,
-            role: Role::Admin,
-            behaviour: Behaviour::Lurker,
-            is_active: None,
-            is_history_private: None,
-            first_login: None,
-            last_login: None,
-            has_verified_email: None,
-            is_profile_private: None,
         })
         .uri("/register");
     let res: ServiceResponse = app.call(req.to_request()).await.unwrap();
@@ -156,7 +130,6 @@ async fn test_login() {
         .set_json(LoginDTO {
             username_or_email: String::from("test_login"),
             password: String::from("test123"),
-            login_timestamp: Utc::now(),
         })
         .uri("/login");
 
@@ -169,7 +142,6 @@ async fn test_login() {
         .set_json(LoginDTO {
             username_or_email: String::from("test_login@laguna.io"),
             password: String::from("test123"),
-            login_timestamp: Utc::now(),
         })
         .uri("/login");
 
@@ -182,7 +154,6 @@ async fn test_login() {
         .set_json(LoginDTO {
             username_or_email: String::from("test_login"),
             password: String::from("seiufhoifhjqow"),
-            login_timestamp: Utc::now(),
         })
         .uri("/login");
 
@@ -194,7 +165,6 @@ async fn test_login() {
         .set_json(LoginDTO {
             username_or_email: String::from("test_loginx"),
             password: String::from("test123"),
-            login_timestamp: Utc::now(),
         })
         .uri("/login");
 
@@ -236,19 +206,10 @@ async fn test_access_and_refresh_token() {
     .await;
 
     let req = TestRequest::post()
-        .set_json(UserDTO {
+        .set_json(RegisterDTO {
             username: String::from("test_access_refresh"),
             email: String::from("test_access_refresh@laguna.io"),
             password: String::from("test123"),
-            avatar_url: None,
-            role: Role::Admin,
-            behaviour: Behaviour::Lurker,
-            is_active: None,
-            is_history_private: None,
-            first_login: None,
-            last_login: None,
-            has_verified_email: None,
-            is_profile_private: None,
         })
         .uri("/register");
     let res: ServiceResponse = app.call(req.to_request()).await.unwrap();
@@ -258,7 +219,6 @@ async fn test_access_and_refresh_token() {
         .set_json(LoginDTO {
             username_or_email: String::from("test_access_refresh"),
             password: String::from("test123"),
-            login_timestamp: Utc::now(),
         })
         .uri("/login");
 

--- a/crates/laguna-backend-model/src/lib.rs
+++ b/crates/laguna-backend-model/src/lib.rs
@@ -1,3 +1,4 @@
 //! Models, DTOs and anything DB.
 pub mod login;
+pub mod register;
 pub mod user;

--- a/crates/laguna-backend-model/src/login.rs
+++ b/crates/laguna-backend-model/src/login.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -6,7 +5,4 @@ pub struct LoginDTO {
     pub username_or_email: String,
     /// Plaintext password.
     pub password: String,
-    /// Timestamp created by client (on click)
-    /// Timestamp cannot be created on server because of latency.
-    pub login_timestamp: DateTime<Utc>,
 }

--- a/crates/laguna-backend-model/src/register.rs
+++ b/crates/laguna-backend-model/src/register.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+/// Data transfer object (DTO) used for registering.
+/// This object is serialized and transfered from the frontend to the backend to register a new user.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RegisterDTO {
+    pub username: String,
+    pub email: String,
+    pub password: String,
+}

--- a/crates/laguna-backend-model/src/user.rs
+++ b/crates/laguna-backend-model/src/user.rs
@@ -12,7 +12,7 @@ pub enum Role {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, sqlx::Type)]
-pub enum  Behaviour {
+pub enum Behaviour {
     Lurker,
     Downloader,
     Freeleecher,
@@ -48,10 +48,11 @@ pub struct User {
 /// This object is serialized and transfered between BE and FE (in API).
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, FromRequest)]
 pub struct UserDTO {
+    /// The user's id
+    pub id: Uuid,
     pub username: String,
     pub email: String,
-    pub password: String,
-    /// If None, DEFAULT is CURRENT_TIMESTAMP
+    /// If None, DEFAULT is CURRENT_TIMESTAMP or we don't have permissions
     pub first_login: Option<DateTime<Utc>>,
     /// If None, DEFAULT is CURRENT_TIMESTAMP
     pub last_login: Option<DateTime<Utc>>,
@@ -71,9 +72,9 @@ pub struct UserDTO {
 impl From<User> for UserDTO {
     fn from(user: User) -> Self {
         Self {
+            id: user.id,
             username: user.username,
             email: user.email,
-            password: user.password,
             first_login: Some(user.first_login),
             last_login: Some(user.last_login),
             avatar_url: user.avatar_url,


### PR DESCRIPTION
- UserDTO no longer sends a password hash
- New DTO for registering that doesn't require null fields
- If the user is already registered, don't return the user's info
- Don't let users set their own role on register
- Return the user id in UserDTO
- Compute the Datetime of login locally on the server

2/3 for #18 Closes #19 Fixes #21 